### PR TITLE
 refactor(errors): return Page<Errors> directly instead of wrapping w…

### DIFF
--- a/src/main/java/com/range/rpms/error/api/ErrorsApi.java
+++ b/src/main/java/com/range/rpms/error/api/ErrorsApi.java
@@ -1,7 +1,6 @@
 package com.range.rpms.error.api;
 
 import com.range.rpms.error.domain.model.Errors;
-import org.apache.coyote.Response;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,13 +9,14 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @RequestMapping("${app.base-path}/errors")
 public interface ErrorsApi {
+
     @GetMapping("/all")
     ResponseEntity<Page<Errors>> findAll(@RequestParam(defaultValue ="10" ) int size,
                                          @RequestParam(defaultValue = "0") int page );
     @GetMapping("/server")
-    ResponseEntity<Page<Errors>> findServerErrors(@RequestParam(defaultValue ="10" ) int size,
-                                                  @RequestParam(defaultValue = "0") int page);
+    Page<Errors> findServerErrors(@RequestParam(defaultValue ="10" ) int size,
+                                  @RequestParam(defaultValue = "0") int page);
     @GetMapping("/client")
-    ResponseEntity<Page<Errors>> findClientErrors(@RequestParam(defaultValue ="10" ) int size,
-                                                  @RequestParam(defaultValue = "0") int page);
+    Page<Errors> findClientErrors(@RequestParam(defaultValue ="10" ) int size,
+                                  @RequestParam(defaultValue = "0") int page);
 }

--- a/src/main/java/com/range/rpms/error/controller/ErrorsController.java
+++ b/src/main/java/com/range/rpms/error/controller/ErrorsController.java
@@ -20,12 +20,12 @@ public class ErrorsController implements ErrorsApi {
     }
 
     @Override
-    public ResponseEntity<Page<Errors>> findServerErrors(int size, int page) {
-        return ResponseEntity.ok(errorService.findServerErrors(size, page));
+    public Page<Errors> findServerErrors(int size, int page) {
+        return errorService.findServerErrors(size, page);
     }
 
     @Override
-    public ResponseEntity<Page<Errors>> findClientErrors(int size, int page) {
-        return ResponseEntity.ok(errorService.findClientErrors(size, page));
+    public Page<Errors>  findClientErrors(int size, int page) {
+        return errorService.findClientErrors(size, page);
     }
 }

--- a/src/main/java/com/range/rpms/user/api/UserSettingApi.java
+++ b/src/main/java/com/range/rpms/user/api/UserSettingApi.java
@@ -1,8 +1,0 @@
-package com.range.rpms.user.api;
-
-public class UserSettingApi {
-
-
-
-
-}


### PR DESCRIPTION
…ith ResponseEntity

- Updated ErrorsApi and ErrorsController methods (findServerErrors, findClientErrors) to return Page<Errors> instead of ResponseEntity<Page<Errors>>
- Added PreAuthorize import for future role-based security handling